### PR TITLE
add hubandspoke.is-not.cool

### DIFF
--- a/domains/hubandspoke.json
+++ b/domains/hubandspoke.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "TyGu1"
+  },
+  "records": {
+    "A": ["92.208.100.224"]
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Adding `hubandspoke.is-not.cool` — a one-page site (giant 💩 filling the screen) self-hosted on a home server.

- `proxied: false` — terminating TLS at origin
- A record → `92.208.100.224`