### PR TITLE
hubandspoke: switch A → AAAA (IPv6)

### DIFF
--- a/domains/hubandspoke.json
+++ b/domains/hubandspoke.json
@@ -3,7 +3,7 @@
     "username": "TyGu1"
   },
   "records": {
-    "A": ["92.208.100.224"]
+    "AAAA": ["2a02:8071:67c1:2b80::9ecb"]
   },
   "proxied": false
 }


### PR DESCRIPTION
My home line is Vodafone DS-Lite (no public IPv4 — the old A record pointed at a shared CGNAT address that is not reachable inbound). Switching `hubandspoke.is-not.cool` to an AAAA record pointing at my host's IPv6 address. `proxied: false` unchanged.