### PR TITLE
Register texting-while-driving.is-not.cool

### DIFF
--- a/domains/texting-while-driving.json
+++ b/domains/texting-while-driving.json
@@ -1,0 +1,12 @@
+{
+    "owner": {
+        "username": "zxyandreay",
+        "email": "zxyandreay@gmail.com",
+        "repo": "https://github.com/zxyandreay/text-drive"
+    },
+
+    "records": {
+        "CNAME": "zxyandreay.github.io"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
# Requirements
- [x] I have **read** and **understood** the Terms of Service.
- [x] I understand my domain will be removed if I violate the Terms of Service.
- [x] My file is in the `domains` directory and has the `.json` file extension.
- [x] My file's name is lowercased and uses a valid hyphenated DNS label (`texting-while-driving`).
- [x] My website is **reachable** and **completed**.
- [x] I have provided sufficient contact information in the `owner` key.

# Website Preview

https://zxyandreay.github.io/text-drive/

# Context

Text & Drive is a small browser game/prototype about distracted driving and split attention. I asked in the is-not.cool Discord server whether this kind of game is allowed, and a maintainer said it should be allowed, so I’d like to attempt registering it.

Requested domain: `texting-while-driving.is-not.cool`